### PR TITLE
Add new attribute for only global errors th:errorsGlobal

### DIFF
--- a/src/main/java/org/thymeleaf/spring3/dialect/SpringStandardDialect.java
+++ b/src/main/java/org/thymeleaf/spring3/dialect/SpringStandardDialect.java
@@ -37,6 +37,7 @@ import org.thymeleaf.doctype.translation.IDocTypeTranslation;
 import org.thymeleaf.processor.IProcessor;
 import org.thymeleaf.spring3.expression.SpelVariableExpressionEvaluator;
 import org.thymeleaf.spring3.processor.attr.SpringErrorsAttrProcessor;
+import org.thymeleaf.spring3.processor.attr.SpringErrorsGlobalAttrProcessor;
 import org.thymeleaf.spring3.processor.attr.SpringInputCheckboxFieldAttrProcessor;
 import org.thymeleaf.spring3.processor.attr.SpringInputFileFieldAttrProcessor;
 import org.thymeleaf.spring3.processor.attr.SpringInputGeneralFieldAttrProcessor;
@@ -451,6 +452,7 @@ public class SpringStandardDialect extends StandardDialect {
         
         processors.add(new SpringObjectAttrProcessor());
         processors.add(new SpringErrorsAttrProcessor());
+        processors.add(new SpringErrorsGlobalAttrProcessor());
         processors.addAll(Arrays.asList(SpringInputGeneralFieldAttrProcessor.PROCESSORS));
         processors.add(new SpringInputPasswordFieldAttrProcessor());
         processors.add(new SpringInputCheckboxFieldAttrProcessor());

--- a/src/main/java/org/thymeleaf/spring3/processor/attr/SpringErrorsGlobalAttrProcessor.java
+++ b/src/main/java/org/thymeleaf/spring3/processor/attr/SpringErrorsGlobalAttrProcessor.java
@@ -1,0 +1,127 @@
+/*
+ * =============================================================================
+ * 
+ *   Copyright (c) 2011-2012, The THYMELEAF team (http://www.thymeleaf.org)
+ * 
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ * 
+ * =============================================================================
+ */
+package org.thymeleaf.spring3.processor.attr;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.web.servlet.support.BindStatus;
+import org.springframework.web.servlet.tags.form.ValueFormatterWrapper;
+import org.thymeleaf.Arguments;
+import org.thymeleaf.Configuration;
+import org.thymeleaf.dom.Element;
+import org.thymeleaf.dom.Node;
+import org.thymeleaf.processor.ProcessorResult;
+import org.thymeleaf.processor.attr.AbstractAttrProcessor;
+import org.thymeleaf.spring3.naming.SpringContextVariableNames;
+import org.thymeleaf.spring3.util.FieldUtils;
+import org.thymeleaf.templateparser.ITemplateParser;
+
+
+
+/**
+ * 
+ * @author Daniel Fern&aacute;ndez
+ * 
+ * @since 1.0
+ *
+ */
+public final class SpringErrorsGlobalAttrProcessor 
+        extends AbstractAttrProcessor {
+
+    private static final String ERROR_DELIMITER = "<br />";
+    
+    public static final int ATTR_PRECEDENCE = 1200;
+    public static final String ATTR_NAME = "errorsGlobal";
+
+    
+
+    
+    
+    public SpringErrorsGlobalAttrProcessor() {
+        super(ATTR_NAME);
+    }
+
+
+    @Override
+    public int getPrecedence() {
+        return ATTR_PRECEDENCE;
+    }
+
+    
+
+    @Override
+    public ProcessorResult processAttribute(
+            final Arguments arguments, final Element element, final String attributeName) {
+        
+        final BindStatus bindStatus = 
+            FieldUtils.getBindStatusGlobal(arguments);
+        
+        if (bindStatus.isError()) {
+            
+            final Map<String,Object> localVariables = new HashMap<String,Object>();
+            localVariables.put(SpringContextVariableNames.SPRING_FIELD_BIND_STATUS, bindStatus);
+            
+            final StringBuilder strBuilder = new StringBuilder();
+            final String[] errorMsgs = bindStatus.getErrorMessages();
+            
+            for (int i = 0; i < errorMsgs.length; i++) {
+                if (i > 0) {
+                    strBuilder.append(ERROR_DELIMITER);
+                }
+                strBuilder.append(
+                        ValueFormatterWrapper.getDisplayString(errorMsgs[i], false));
+            }
+            
+            // Remove previous element children
+            element.clearChildren();
+            
+            
+            final Configuration configuration = arguments.getConfiguration();
+            
+            final ITemplateParser templateParser =
+                    configuration.getTemplateModeHandler(
+                            arguments.getTemplateResolution().getTemplateMode()).getTemplateParser();
+            
+            // Use the parser to obtain a DOM from the String
+            final List<Node> fragNodes = templateParser.parseFragment(configuration, strBuilder.toString());
+
+            for (final Node child : fragNodes) {
+                child.setProcessable(false);
+                element.addChild(child);
+            }
+            
+            element.removeAttribute(attributeName);
+            
+            return ProcessorResult.setLocalVariables(localVariables);
+            
+        }
+        
+        element.getParent().removeChild(element);
+        
+        return ProcessorResult.OK;
+        
+    }
+
+        
+    
+
+}


### PR DESCRIPTION
The JSTL form:errors tag display only global Errors. With thymeleaf attribute  errors="*"it  display global errors and field errors.

Now I created a new attribute errorsGlobal that only show global errors without field errors. 

I have create a patch. 
You can use the new attribute with th:errorsGlobal="".
