### PR TITLE
Ability to set input's value if corresponding value of model attribute is null

### DIFF
--- a/thymeleaf-spring3/src/main/java/org/thymeleaf/spring3/processor/attr/SpringInputGeneralFieldAttrProcessor.java
+++ b/thymeleaf-spring3/src/main/java/org/thymeleaf/spring3/processor/attr/SpringInputGeneralFieldAttrProcessor.java
@@ -115,8 +115,10 @@ public final class SpringInputGeneralFieldAttrProcessor
         // Thanks to precedence, this should have already been computed
         final String type = element.getAttributeValueFromNormalizedName("type");
 
+        final Object valueObj = getValue(bindStatus, element);
+
         // No escaping needed as attribute values are always escaped by default
-        final String value = ValueFormatterWrapper.getDisplayString(bindStatus.getValue(), bindStatus.getEditor(), false);
+        final String value = ValueFormatterWrapper.getDisplayString(valueObj, bindStatus.getEditor(), false);
         
         element.setAttribute("id", id);
         element.setAttribute("name", name);
@@ -132,6 +134,22 @@ public final class SpringInputGeneralFieldAttrProcessor
         
     }
 
-    
+    /**
+     * Useful for cases when you would like to set value from {@link
+     * org.springframework.ui.Model Model}'s attribute instead of {@link
+     * org.springframework.web.bind.annotation.ModelAttribute ModelAttribute}'s
+     * field when this field is null
+     *
+     * @param bindStatus field bind status
+     * @param element
+     * @return bind status value if it's not null or {@link
+     * org.thymeleaf.dom.Element Element}'s value of "value" attribute
+     */
+    private Object getValue(final BindStatus bindStatus, final Element element) {
+        if (bindStatus.getValue() == null) {
+            return element.getAttributeValue("value");
+        }
+        return bindStatus.getValue();
+    }
 
 }

--- a/thymeleaf-spring4/src/main/java/org/thymeleaf/spring4/processor/attr/SpringInputGeneralFieldAttrProcessor.java
+++ b/thymeleaf-spring4/src/main/java/org/thymeleaf/spring4/processor/attr/SpringInputGeneralFieldAttrProcessor.java
@@ -115,8 +115,10 @@ public final class SpringInputGeneralFieldAttrProcessor
         // Thanks to precedence, this should have already been computed
         final String type = element.getAttributeValueFromNormalizedName("type");
 
+        final Object valueObj = getValue(bindStatus, element);
+
         // No escaping needed as attribute values are always escaped by default
-        final String value = ValueFormatterWrapper.getDisplayString(bindStatus.getValue(), bindStatus.getEditor(), false);
+        final String value = ValueFormatterWrapper.getDisplayString(valueObj, bindStatus.getEditor(), false);
         
         element.setAttribute("id", id);
         element.setAttribute("name", name);
@@ -132,6 +134,22 @@ public final class SpringInputGeneralFieldAttrProcessor
         
     }
 
-    
+    /**
+     * Useful for cases when you would like to set value from {@link
+     * org.springframework.ui.Model Model}'s attribute instead of {@link
+     * org.springframework.web.bind.annotation.ModelAttribute ModelAttribute}'s
+     * field when this field is null
+     *
+     * @param bindStatus field bind status
+     * @param element
+     * @return bind status value if it's not null or {@link
+     * org.thymeleaf.dom.Element Element}'s value of "value" attribute
+     */
+    private Object getValue(final BindStatus bindStatus, final Element element) {
+        if (bindStatus.getValue() == null) {
+            return element.getAttributeValue("value");
+        }
+        return bindStatus.getValue();
+    }
 
 }


### PR DESCRIPTION
I have faced the following problem: in my app I'd like to set hidden form input value from incoming model to model attribute field. Here code example:
FormDto

``` java
public class FormDto {
    private String field;
    //getter and setter
}
```

Controller

``` java
@ModelAttribute("formDto")
public FormDto getFormDto(){
    return new FormDto();
}

@RequestMapping("/form")
public String fillForm(Model model){
    model.addAttribute("formField", "testFormField");
    return "form";
}
```

form.html

``` html
<form method="post" th:action="@{/post-form}" th:object="${formDto}">
    <input type="hidden" th:field="*{field}" th:value="${formField}"/>
</form>
```

After parsing have the following result:

``` html
<form method="post" action="/post-form">
    <input type="hidden" id="mark" name="mark" value>
</form>
```

As we can see value is omitted.

In pull request I've created ability to get value of "value" attribute if corresponding field in ModelAttribute is null. It can be very useful for hidden fields.

Thank you for you time
