### PR TITLE
Fixing issue  #81

### DIFF
--- a/thymeleaf-spring3/src/main/java/org/thymeleaf/spring3/view/ThymeleafViewResolver.java
+++ b/thymeleaf-spring3/src/main/java/org/thymeleaf/spring3/view/ThymeleafViewResolver.java
@@ -605,21 +605,21 @@ public class ThymeleafViewResolver
     
     @Override
     protected View createView(final String viewName, final Locale locale) throws Exception {
-        if (!canHandle(viewName, locale)) {
-            vrlogger.trace("[THYMELEAF] View \"{}\" cannot be handled by ThymeleafViewResolver. Passing on to the next resolver in the chain.", viewName);
-            return null;
-        }
         if (viewName.startsWith(REDIRECT_URL_PREFIX)) {
             vrlogger.trace("[THYMELEAF] View \"{}\" is a redirect, and will not be handled directly by ThymeleafViewResolver.", viewName);
             final String redirectUrl = viewName.substring(REDIRECT_URL_PREFIX.length());
             final RedirectView view = new RedirectView(redirectUrl, isRedirectContextRelative(), isRedirectHttp10Compatible());
-			view.setApplicationContext(getApplicationContext());
-			return view;
+			      view.setApplicationContext(getApplicationContext());
+			      return view;
         }
         if (viewName.startsWith(FORWARD_URL_PREFIX)) {
             vrlogger.trace("[THYMELEAF] View \"{}\" is a forward, and will not be handled directly by ThymeleafViewResolver.", viewName);
             final String forwardUrl = viewName.substring(FORWARD_URL_PREFIX.length());
             return new InternalResourceView(forwardUrl);
+        }
+        if (!canHandle(viewName, locale)) {
+            vrlogger.trace("[THYMELEAF] View \"{}\" cannot be handled by ThymeleafViewResolver. Passing on to the next resolver in the chain.", viewName);
+            return null;
         }
         vrlogger.trace("[THYMELEAF] View {} will be handled by ThymeleafViewResolver and a " +
         		"{} instance will be created for it", viewName, this.viewClass.getSimpleName());

--- a/thymeleaf-spring4/src/main/java/org/thymeleaf/spring4/view/ThymeleafViewResolver.java
+++ b/thymeleaf-spring4/src/main/java/org/thymeleaf/spring4/view/ThymeleafViewResolver.java
@@ -605,21 +605,21 @@ public class ThymeleafViewResolver
     
     @Override
     protected View createView(final String viewName, final Locale locale) throws Exception {
-        if (!canHandle(viewName, locale)) {
-            vrlogger.trace("[THYMELEAF] View \"{}\" cannot be handled by ThymeleafViewResolver. Passing on to the next resolver in the chain.", viewName);
-            return null;
-        }
         if (viewName.startsWith(REDIRECT_URL_PREFIX)) {
             vrlogger.trace("[THYMELEAF] View \"{}\" is a redirect, and will not be handled directly by ThymeleafViewResolver.", viewName);
             final String redirectUrl = viewName.substring(REDIRECT_URL_PREFIX.length());
-			final RedirectView view = new RedirectView(redirectUrl, isRedirectContextRelative(), isRedirectHttp10Compatible());
-			view.setApplicationContext(getApplicationContext());
-			return view;
+            final RedirectView view = new RedirectView(redirectUrl, isRedirectContextRelative(), isRedirectHttp10Compatible());
+            view.setApplicationContext(getApplicationContext());
+			      return view;
         }
         if (viewName.startsWith(FORWARD_URL_PREFIX)) {
             vrlogger.trace("[THYMELEAF] View \"{}\" is a forward, and will not be handled directly by ThymeleafViewResolver.", viewName);
             final String forwardUrl = viewName.substring(FORWARD_URL_PREFIX.length());
             return new InternalResourceView(forwardUrl);
+        }
+        if (!canHandle(viewName, locale)) {
+            vrlogger.trace("[THYMELEAF] View \"{}\" cannot be handled by ThymeleafViewResolver. Passing on to the next resolver in the chain.", viewName);
+            return null;
         }
         vrlogger.trace("[THYMELEAF] View {} will be handled by ThymeleafViewResolver and a " +
         		"{} instance will be created for it", viewName, this.viewClass.getSimpleName());


### PR DESCRIPTION
In createView(final String viewName, final Locale locale), the first thing done is to call canHandle(final String viewName, @SuppressWarnings("unused") final Locale locale). If the result is false, null is returned. The canHandle method doesn't check if the viewName starts with redirect: or forward:, so the checks after the call are useless. Either move the the call to the canHandle method to after handling redirect and forward, or add checks to the canHandle method. I prefer the former solution, since the latter will have extra processing overhead.
