### PR TITLE
Fixed FieldUtils.isBound to properly use

### DIFF
--- a/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/util/FieldUtils.java
+++ b/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/util/FieldUtils.java
@@ -379,7 +379,7 @@ public final class FieldUtils {
         final String beanName = completeExpression.substring(0, dotPos);
 
         // The getErrors() method is not extremely efficient, but it has a cache map, so it should be fine
-        final boolean beanValid = requestContext.getErrors(beanName, false) != null;
+        final boolean beanValid = requestContext.getErrors(beanName, false).isPresent();
         if (beanValid && completeExpression.length() > dotPos) {
             final String path = completeExpression.substring(dotPos + 1, completeExpression.length() - 1);
             // We will validate the rest of the expression as a bean property identifier or a bean property expression.


### PR DESCRIPTION
…IThymeleafRequestContext.getErrors in thymeleaf-spring5.

Obviously, without this fix, 'beanValid' is always true. I encountered this bug when using th:each:
"Neither BindingResult nor plain target object for bean name 'abc' available as request attribute", where 'abc' is the iterating variable.
