### PR TITLE
Fix #175: Cannot call #fields.detailedErrors() from a Spring Webflow form

### DIFF
--- a/thymeleaf-spring3/src/main/java/org/thymeleaf/spring3/util/FieldUtils.java
+++ b/thymeleaf-spring3/src/main/java/org/thymeleaf/spring3/util/FieldUtils.java
@@ -164,7 +164,12 @@ public final class FieldUtils {
         }
 
         if (bindExpression != null) {
-            final List<FieldError> fieldErrors = errors.getFieldErrors(bindStatus.getExpression());
+            final List<FieldError> fieldErrors;
+            if (ALL_EXPRESSION.equals(bindExpression) || ALL_FIELDS.equals(bindExpression)) {
+                fieldErrors = errors.getFieldErrors();
+            } else {
+                fieldErrors = errors.getFieldErrors(bindExpression);
+            }
             for (final FieldError fieldError : fieldErrors) {
                 final String message = requestContext.getMessage(fieldError, false);
                 final DetailedError errorObject =

--- a/thymeleaf-spring4/src/main/java/org/thymeleaf/spring4/util/FieldUtils.java
+++ b/thymeleaf-spring4/src/main/java/org/thymeleaf/spring4/util/FieldUtils.java
@@ -164,7 +164,12 @@ public final class FieldUtils {
         }
 
         if (bindExpression != null) {
-            final List<FieldError> fieldErrors = errors.getFieldErrors(bindStatus.getExpression());
+            final List<FieldError> fieldErrors;
+            if (ALL_EXPRESSION.equals(bindExpression) || ALL_FIELDS.equals(bindExpression)) {
+                fieldErrors = errors.getFieldErrors();
+            } else {
+                fieldErrors = errors.getFieldErrors(bindExpression);
+            }
             for (final FieldError fieldError : fieldErrors) {
                 final String message = requestContext.getMessage(fieldError, false);
                 final DetailedError errorObject =

--- a/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/util/FieldUtils.java
+++ b/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/util/FieldUtils.java
@@ -163,7 +163,12 @@ public final class FieldUtils {
         }
 
         if (bindExpression != null) {
-            final List<FieldError> fieldErrors = errors.getFieldErrors(bindStatus.getExpression());
+            final List<FieldError> fieldErrors;
+            if (ALL_EXPRESSION.equals(bindExpression) || ALL_FIELDS.equals(bindExpression)) {
+                fieldErrors = errors.getFieldErrors();
+            } else {
+                fieldErrors = errors.getFieldErrors(bindExpression);
+            }
             for (final FieldError fieldError : fieldErrors) {
                 final String message = requestContext.getMessage(fieldError, false);
                 final DetailedError errorObject =


### PR DESCRIPTION
Using `#fields.detailedErrors()` with spring-webflow 2.3.1 will call its org.springframework.webflow.mvc.view.BindingModel.getFieldErrors(java.lang.String) with "*" as argument. However specifing "*" leads to the error that a non-empty prefix is expected; calling the parameter-less version works as expected.

I checked back into the repository and the behaviour is unchanged since 2.3.1:
-  [`getFieldErrors(java.lang.String)`](https://github.com/spring-projects/spring-webflow/blob/962cb673cfb5bf5d2b92e0378d911dcfa3da7a29/spring-webflow/src/main/java/org/springframework/webflow/mvc/view/BindingModel.java#L123) delegates calls `new FieldPrefixErrorMessage(String)` when the input ends in *, removing the last character
- [`new FieldPrefixErrorMessage(String)`](https://github.com/spring-projects/spring-webflow/blob/962cb673cfb5bf5d2b92e0378d911dcfa3da7a29/spring-webflow/src/main/java/org/springframework/webflow/mvc/view/BindingModel.java#L344) then asserts that a non-empty prefix is given, which will result in an exception as the only character was removed.

Feel free to propose another fix, but from what I see in spring-webflow's BindingModel there are not many other approaches. Probably calling `getAllErrors()` would also be an option, too. 
