### PR TITLE
Added inputStream method to ITemplateResources

### DIFF
--- a/thymeleaf-spring3/src/main/java/org/thymeleaf/spring3/templateresource/SpringResourceTemplateResource.java
+++ b/thymeleaf-spring3/src/main/java/org/thymeleaf/spring3/templateresource/SpringResourceTemplateResource.java
@@ -99,8 +99,7 @@ public final class SpringResourceTemplateResource implements ITemplateResource {
 
     public Reader reader() throws IOException {
 
-        // Will never return null, but an IOException if not found
-        final InputStream inputStream = this.resource.getInputStream();
+        final InputStream inputStream = inputStream();
 
         if (!StringUtils.isEmptyOrWhitespace(this.characterEncoding)) {
             return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream), this.characterEncoding));
@@ -108,6 +107,11 @@ public final class SpringResourceTemplateResource implements ITemplateResource {
 
         return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream)));
 
+    }
+
+    public InputStream inputStream() throws IOException {
+        // Will never return null, but an IOException if not found
+        return this.resource.getInputStream();
     }
 
     public ITemplateResource relative(final String relativeLocation) {
@@ -192,6 +196,11 @@ public final class SpringResourceTemplateResource implements ITemplateResource {
 
         @Override
         public Reader reader() throws IOException {
+            throw new IOException("Invalid relative resource", this.ioException);
+        }
+
+        @Override
+        public InputStream inputStream() throws IOException {
             throw new IOException("Invalid relative resource", this.ioException);
         }
 

--- a/thymeleaf-spring4/src/main/java/org/thymeleaf/spring4/templateresource/SpringResourceTemplateResource.java
+++ b/thymeleaf-spring4/src/main/java/org/thymeleaf/spring4/templateresource/SpringResourceTemplateResource.java
@@ -100,7 +100,7 @@ public final class SpringResourceTemplateResource implements ITemplateResource {
     public Reader reader() throws IOException {
 
         // Will never return null, but an IOException if not found
-        final InputStream inputStream = this.resource.getInputStream();
+        final InputStream inputStream = inputStream();
 
         if (!StringUtils.isEmptyOrWhitespace(this.characterEncoding)) {
             return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream), this.characterEncoding));
@@ -108,6 +108,11 @@ public final class SpringResourceTemplateResource implements ITemplateResource {
 
         return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream)));
 
+    }
+
+    public InputStream inputStream() throws IOException {
+        // Will never return null, but an IOException if not found
+        return this.resource.getInputStream();
     }
 
     public ITemplateResource relative(final String relativeLocation) {
@@ -192,6 +197,11 @@ public final class SpringResourceTemplateResource implements ITemplateResource {
 
         @Override
         public Reader reader() throws IOException {
+            throw new IOException("Invalid relative resource", this.ioException);
+        }
+
+        @Override
+        public InputStream inputStream() throws IOException {
             throw new IOException("Invalid relative resource", this.ioException);
         }
 

--- a/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/templateresource/SpringResourceTemplateResource.java
+++ b/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/templateresource/SpringResourceTemplateResource.java
@@ -99,8 +99,7 @@ public final class SpringResourceTemplateResource implements ITemplateResource {
 
     public Reader reader() throws IOException {
 
-        // Will never return null, but an IOException if not found
-        final InputStream inputStream = this.resource.getInputStream();
+        final InputStream inputStream = inputStream();
 
         if (!StringUtils.isEmptyOrWhitespace(this.characterEncoding)) {
             return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream), this.characterEncoding));
@@ -108,6 +107,11 @@ public final class SpringResourceTemplateResource implements ITemplateResource {
 
         return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream)));
 
+    }
+
+    public InputStream inputStream() throws IOException {
+        // Will never return null, but an IOException if not found
+        return this.resource.getInputStream();
     }
 
     public ITemplateResource relative(final String relativeLocation) {
@@ -192,6 +196,11 @@ public final class SpringResourceTemplateResource implements ITemplateResource {
 
         @Override
         public Reader reader() throws IOException {
+            throw new IOException("Invalid relative resource", this.ioException);
+        }
+
+        @Override
+        public InputStream inputStream() throws IOException {
             throw new IOException("Invalid relative resource", this.ioException);
         }
 


### PR DESCRIPTION
The main reason for adding this is our usecase of using thymeleaf for e-mail templates.

To refer to images and other binary resources, I created an extension tag processor that reads the resource, adds it to a special container in a context, and outputs a "cid:unique-code" url to refer to the image. However I need to be able to load the resource as binary data, and ITemplateResource only has a `reader` method. I added an `inputStream` method to ITemplateResource and all its implementations in the thymeleaf and thymeleaf-spring repositories. I added a unit test so that this method has the same amount of testing as the `reader` method. 

(Since the `reader` methods were all changes to use the `inputStream` method to avoid code duplication, the ability to load a resource at all also means that the `inputStream()` method worked, so it's implicitly tested in many more cases, just as the `reader` method is)

This pull request has accompanying pull requests in thymeleaf-tests and thymeleaf repositories.