### PR TITLE
Allow hiding model attributes in redirects

### DIFF
--- a/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/view/ThymeleafViewResolver.java
+++ b/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/view/ThymeleafViewResolver.java
@@ -91,6 +91,7 @@ public class ThymeleafViewResolver
 
     private boolean redirectContextRelative = true;
     private boolean redirectHttp10Compatible = true;
+    private boolean redirectExposeModelAttributes = true;
 
     private boolean alwaysProcessRedirectAndForward = true;
 
@@ -523,8 +524,35 @@ public class ThymeleafViewResolver
     public boolean isRedirectHttp10Compatible() {
         return this.redirectHttp10Compatible;
     }
-    
-    
+
+
+    /**
+     * <p>
+     *     Set whether model attributes should be appended to the URI, when performing a redirection.
+     * </p>
+     *
+     * @param redirectExposeModelAttributes true if model attributes should be appended to the redirect URI,
+     *        false if not
+     * @see RedirectView#setExposeModelAttributes(boolean)
+     */
+    public void setRedirectExposeModelAttributes(final boolean redirectExposeModelAttributes) {
+        this.redirectExposeModelAttributes = redirectExposeModelAttributes;
+    }
+
+
+    /**
+     * <p>
+     *     Return whether model attributes should be appended to the URI, when performing a redirection.
+     * </p>
+     *
+     * @return whether model attributes should be appended to the URI, when performing a redirection.
+     * @see RedirectView#setExposeModelAttributes(boolean)
+     *
+     */
+    public boolean shouldRedirectExposeModelAttributes() {
+        return this.redirectExposeModelAttributes;
+    }
+
 
     /**
      * <p>
@@ -775,7 +803,7 @@ public class ThymeleafViewResolver
         if (viewName.startsWith(REDIRECT_URL_PREFIX)) {
             vrlogger.trace("[THYMELEAF] View \"{}\" is a redirect, and will not be handled directly by ThymeleafViewResolver.", viewName);
             final String redirectUrl = viewName.substring(REDIRECT_URL_PREFIX.length(), viewName.length());
-            final RedirectView view = new RedirectView(redirectUrl, isRedirectContextRelative(), isRedirectHttp10Compatible());
+            final RedirectView view = new RedirectView(redirectUrl, isRedirectContextRelative(), isRedirectHttp10Compatible(), shouldRedirectExposeModelAttributes());
             return (View) getApplicationContext().getAutowireCapableBeanFactory().initializeBean(view, REDIRECT_URL_PREFIX);
         }
         // Process forwards (to JSP resources)

--- a/thymeleaf-spring6/src/main/java/org/thymeleaf/spring6/view/ThymeleafViewResolver.java
+++ b/thymeleaf-spring6/src/main/java/org/thymeleaf/spring6/view/ThymeleafViewResolver.java
@@ -91,6 +91,7 @@ public class ThymeleafViewResolver
 
     private boolean redirectContextRelative = true;
     private boolean redirectHttp10Compatible = true;
+    private boolean redirectExposeModelAttributes = true;
 
     private boolean alwaysProcessRedirectAndForward = true;
 
@@ -525,6 +526,33 @@ public class ThymeleafViewResolver
     }
 
 
+    /**
+     * <p>
+     *     Set whether model attributes should be appended to the URI, when performing a redirection.
+     * </p>
+     *
+     * @param redirectExposeModelAttributes true if model attributes should be appended to the redirect URI,
+     *        false if not
+     * @see RedirectView#setExposeModelAttributes(boolean)
+     */
+    public void setRedirectExposeModelAttributes(final boolean redirectExposeModelAttributes) {
+        this.redirectExposeModelAttributes = redirectExposeModelAttributes;
+    }
+
+
+    /**
+     * <p>
+     *     Return whether model attributes should be appended to the URI, when performing a redirection.
+     * </p>
+     *
+     * @return whether model attributes should be appended to the URI, when performing a redirection.
+     * @see RedirectView#setExposeModelAttributes(boolean)
+     *
+     */
+    public boolean shouldRedirectExposeModelAttributes() {
+        return this.redirectExposeModelAttributes;
+    }
+
 
     /**
      * <p>
@@ -775,7 +803,7 @@ public class ThymeleafViewResolver
         if (viewName.startsWith(REDIRECT_URL_PREFIX)) {
             vrlogger.trace("[THYMELEAF] View \"{}\" is a redirect, and will not be handled directly by ThymeleafViewResolver.", viewName);
             final String redirectUrl = viewName.substring(REDIRECT_URL_PREFIX.length(), viewName.length());
-            final RedirectView view = new RedirectView(redirectUrl, isRedirectContextRelative(), isRedirectHttp10Compatible());
+            final RedirectView view = new RedirectView(redirectUrl, isRedirectContextRelative(), isRedirectHttp10Compatible(), shouldRedirectExposeModelAttributes());
             return (View) getApplicationContext().getAutowireCapableBeanFactory().initializeBean(view, REDIRECT_URL_PREFIX);
         }
         // Process forwards (to JSP resources)


### PR DESCRIPTION
Context
-------

Spring Web MVC allows performing redirections by returning a String prefixed by `redirect://` in the controller.

This String is intercepted by `ThymeleafViewResolver` which maps it to an instance of `RedirectView`.

Problem
-------

The default behaviour of `RedirectView` is to include all model attributes as query parameters.

This behaviour may not be desirable and thymeleaf-spring does not provide a way to easily change it.

Suggested fix
-------------

Expose a method called `setRedirectExposeModelAttributes` in `ThymeleafViewResolver` to allow overriding this behaviour.