### PR TITLE
Update pom.xml bump  servlet-api version to 4.0.0

### DIFF
--- a/thymeleaf-spring5/pom.xml
+++ b/thymeleaf-spring5/pom.xml
@@ -116,7 +116,7 @@
     <!-- NOTE module name is fixed and not set to project.artifactId because this would not be a     -->
     <!-- valid approach for project names containing hyphens, which are not allowed in module names. -->
     <module.name>thymeleaf.spring5</module.name>
-    <servlet-api.version>2.5</servlet-api.version>
+    <servlet-api.version>4.0.0</servlet-api.version>
     <springframework.version>5.0.8.RELEASE</springframework.version>
     <springwebflow.version>2.5.0.RELEASE</springwebflow.version>
     <slf4j.version>1.7.32</slf4j.version>

--- a/thymeleaf-spring5/pom.xml
+++ b/thymeleaf-spring5/pom.xml
@@ -329,7 +329,7 @@
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <version>${servlet-api.version}</version>
       <scope>provided</scope>
       <optional>true</optional>


### PR DESCRIPTION
According to Spring framework 5 release tag source code.
Line 16 [Here](https://github.com/spring-projects/spring-framework/blob/v5.0.0.RELEASE/spring-webmvc/spring-webmvc.gradle)

Spring framwork 5 need at least `javax.servlet:javax.servlet-api:4.0.0`  bump version.
```groovy
    provided("javax.servlet:javax.servlet-api:4.0.0")
```